### PR TITLE
フロント・API統合: URL入力→リライト表示フローの完成

### DIFF
--- a/src/components/RewriteForm.tsx
+++ b/src/components/RewriteForm.tsx
@@ -40,7 +40,7 @@ export default function RewriteForm() {
 
     try {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 30000);
+      const timeout = setTimeout(() => controller.abort(), 60000);
 
       // 1. 記事を抽出
       const extractRes = await fetch("/api/extract", {
@@ -118,11 +118,21 @@ export default function RewriteForm() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded-lg bg-primary px-6 py-3 text-base font-medium text-white transition-colors hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-base font-medium text-white transition-colors hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-50"
         >
+          {loading && (
+            <span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+          )}
           {loading ? "リライト中..." : "ほろ酔みリライト"}
         </button>
       </form>
+
+      {loading && (
+        <div className="flex flex-col items-center gap-3 py-8 text-muted">
+          <span className="inline-block h-8 w-8 animate-spin rounded-full border-3 border-primary border-t-transparent" />
+          <p className="text-sm">記事を取得してリライトしています...</p>
+        </div>
+      )}
 
       {result && (
         <div className="rounded-xl border border-border bg-surface p-6">


### PR DESCRIPTION
## Summary
- ローディングスピナーをボタン内とフォーム下部に追加し、処理中の視覚的フィードバックを改善
- LLMリライト処理を考慮してタイムアウトを30秒→60秒に延長

Closes #6

## 既存実装の確認
以下はブランチ作成前（integrate-all PR）で既に実装済み：
- URL入力 + 難易度選択 → POST /api/extract → POST /api/rewrite の統合フロー
- ReactMarkdownによるマークダウン形式のリライト結果表示
- react-hot-toastによるエラーメッセージ表示
- `npm run build` 成功確認済み

## Test plan
- [ ] 実在する技術記事URLでリライト結果が表示されること
- [ ] 存在しないURLでエラーメッセージが表示されること
- [ ] ローディング中にスピナーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)